### PR TITLE
Fix kid queryString in key endpoint

### DIFF
--- a/src/inference/keyEndpoint.ts
+++ b/src/inference/keyEndpoint.ts
@@ -107,14 +107,24 @@ export const key = (
   }
 
   // Check kid
-  let kid = serviceRequest.body?.["kid"];
+  let kidString = serviceRequest.query?.["kid"];
+  let kid: number | undefined;
   let keyItem: IKeyItem | undefined;
-  if (kid === undefined) {
+  if (kidString === undefined) {
     [kid, keyItem] = hpkeKeyMap.latestItem();
     if (keyItem === undefined) {
       return ServiceResult.Failed<string>(
         { errorMessage: `${name}: No keys in store` },
         400,
+      );
+    }
+  } else {
+    kid = parseInt(kidString, 10);
+    keyItem = hpkeKeyMap.store.get(kid) as IKeyItem;
+    if (keyItem === undefined) {
+      return ServiceResult.Failed<string>(
+        { errorMessage: `${name}: kid ${kid} not found in store` },
+        404,
       );
     }
   }


### PR DESCRIPTION
There were a couple of issues which prevented the queryString `kid` from working

- It is defined as a number but passed in as a string
- There was no code to look up the keyItem in the case it was defined

This addresses both issues