### PR TITLE
Add new MAA test endpoint confinfermaaeus2test

### DIFF
--- a/governance/jwt/set_jwt_maa_validation_policy_proposal.json
+++ b/governance/jwt/set_jwt_maa_validation_policy_proposal.json
@@ -46,7 +46,7 @@
     {
       "name": "set_jwt_issuer",
       "args": {
-        "issuer": "https://accnosecurebootmaa.eus2.attest.azure.net",
+        "issuer": "https://confinfermaaeus2test.eus2.test.attest.azure.net",
         "key_filter": "all",
         "ca_cert_bundle_name": "jwt_maa",
         "auto_refresh": true
@@ -55,27 +55,9 @@
     {
       "name": "set_jwt_validation_policy",
       "args": {
-        "issuer": "https://accnosecurebootmaa.eus2.attest.azure.net",
+        "issuer": "https://confinfermaaeus2test.eus2.test.attest.azure.net",
         "validation_policy": {
-          "iss": "https://accnosecurebootmaa.eus2.attest.azure.net"
-        }
-      }
-    },
-    {
-      "name": "set_jwt_issuer",
-      "args": {
-        "issuer": "https://accnosecurebootmaawesteu.weu.attest.azure.net",
-        "key_filter": "all",
-        "ca_cert_bundle_name": "jwt_maa",
-        "auto_refresh": true
-      }
-    },
-    {
-      "name": "set_jwt_validation_policy",
-      "args": {
-        "issuer": "https://accnosecurebootmaawesteu.weu.attest.azure.net",
-        "validation_policy": {
-          "iss": "https://accnosecurebootmaawesteu.weu.attest.azure.net"
+          "iss": "https://confinfermaaeus2test.eus2.test.attest.azure.net"
         }
       }
     }

--- a/src/authorization/jwt/JwtIdentityProviderEnum.ts
+++ b/src/authorization/jwt/JwtIdentityProviderEnum.ts
@@ -9,6 +9,7 @@ export enum JwtIdentityProviderEnum {
   Demo = "http://Demo-jwt-issuer",
   MAA_deus2 = "https://sharedeus2.eus2.attest.azure.net",
   MAA_NoSecureBootTyFu = "https://maanosecureboottestyfu.eus.attest.azure.net",
-  MAA_NoSecureBootWeu = "https://accnosecurebootmaawesteu.weu.attest.azure.net",
-  MAA_NoSecureBootEus = "https://accnosecurebootmaa.eus2.attest.azure.net",
+  MAA_ConfInferenceTestEus2 = "https://confinfermaaeus2test.eus2.test.attest.azure.net",
+  // MAA_NoSecureBootWeu = "https://accnosecurebootmaawesteu.weu.attest.azure.net",
+  // MAA_NoSecureBootEus = "https://accnosecurebootmaa.eus2.attest.azure.net",
 }

--- a/src/authorization/jwt/JwtValidator.ts
+++ b/src/authorization/jwt/JwtValidator.ts
@@ -38,23 +38,32 @@ export class JwtValidator implements IValidatorService {
       this.logContext
     );
     this.identityProviders.set(
-      JwtIdentityProviderEnum.MAA_NoSecureBootWeu,
+      JwtIdentityProviderEnum.MAA_ConfInferenceTestEus2,
       new MsJwtProvider("JwtMaaProvider", this.logContext),
     );
     Logger.debug(
-      "JwtIdentityProviderEnum.MAA_NoSecureBootWeu",
-      JwtIdentityProviderEnum.MAA_NoSecureBootWeu,
+      "JwtIdentityProviderEnum.MAA_ConfInferenceTestEus2",
+      JwtIdentityProviderEnum.MAA_ConfInferenceTestEus2,
       this.logContext
     );
-    this.identityProviders.set(
-      JwtIdentityProviderEnum.MAA_NoSecureBootEus,
-      new MsJwtProvider("JwtMaaProvider", this.logContext),
-    );
-    Logger.debug(
-      "JwtIdentityProviderEnum.MAA_NoSecureBootEus",
-      JwtIdentityProviderEnum.MAA_NoSecureBootEus,
-      this.logContext
-    );
+    // this.identityProviders.set(
+    //   JwtIdentityProviderEnum.MAA_NoSecureBootWeu,
+    //   new MsJwtProvider("JwtMaaProvider", this.logContext),
+    // );
+    // Logger.debug(
+    //   "JwtIdentityProviderEnum.MAA_NoSecureBootWeu",
+    //   JwtIdentityProviderEnum.MAA_NoSecureBootWeu,
+    //   this.logContext
+    // );
+    // this.identityProviders.set(
+    //   JwtIdentityProviderEnum.MAA_NoSecureBootEus,
+    //   new MsJwtProvider("JwtMaaProvider", this.logContext),
+    // );
+    // Logger.debug(
+    //   "JwtIdentityProviderEnum.MAA_NoSecureBootEus",
+    //   JwtIdentityProviderEnum.MAA_NoSecureBootEus,
+    //   this.logContext
+    // );
     this.identityProviders.set(
       JwtIdentityProviderEnum.MS_AAD,
       new MsJwtProvider("JwtProvider", this.logContext),


### PR DESCRIPTION
This pull request includes changes to update the JWT issuer URLs and modify the JWT identity provider configurations. The most important changes are summarized below:

### JWT Issuer URL Updates:
* Updated the issuer URL in the `set_jwt_maa_validation_policy_proposal.json` file to `https://confinfermaaeus2test.eus2.test.attest.azure.net` for both `set_jwt_issuer` and `set_jwt_validation_policy` entries. [[1]](diffhunk://#diff-1f59ebd61457777a710b19807709a1a46c36d6b50707db4ef50d309c3900c006L49-R49) [[2]](diffhunk://#diff-1f59ebd61457777a710b19807709a1a46c36d6b50707db4ef50d309c3900c006L58-R60)

### JWT Identity Provider Enum and Validator Updates:
* Added a new entry `MAA_ConfInferenceTestEus2` in the `JwtIdentityProviderEnum` and commented out the old entries `MAA_NoSecureBootWeu` and `MAA_NoSecureBootEus` in `JwtIdentityProviderEnum.ts`.
* Updated the `JwtValidator` class to use the new `MAA_ConfInferenceTestEus2` identity provider and commented out the old identity provider configurations in `JwtValidator.ts`.