### PR TITLE
Change claim for receipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ curl ${KMS_URL}/app/refresh -X POST --cacert ${KEYS_DIR}/service_cert.pem  -H "C
 curl ${KMS_URL}/app/listpubkeys --cacert ${KEYS_DIR}/service_cert.pem  -H "Content-Type: application/json" -i  -w '\n'
 
 # Get the latest private key (JWT)
+curl $KMS_URL/app/key -X POST --cacert ${KEYS_DIR}/service_cert.pem  -H "Content-Type: application/json" -H "Authorization:$AUTHORIZATION"  -w '\n'
 
 # Get key release policy
 curl $KMS_URL/app/keyReleasePolicy --cacert ${KEYS_DIR}/service_cert.pem --cert ${KEYS_DIR}/member0_cert.pem --key ${KEYS_DIR}/member0_privk.pem -H "Content-Type: application/json" | jq

--- a/src/inference/refreshEndpoint.ts
+++ b/src/inference/refreshEndpoint.ts
@@ -9,6 +9,7 @@ import { KeyGeneration } from "./KeyGeneration";
 import { enableEndpoint } from "../utils/Tooling";
 import { ServiceRequest } from "../utils/ServiceRequest";
 import { Logger, LogContext } from "../utils/Logger";
+import { OhttpPublicKey } from "./OhttpPublicKey";
 
 // Enable the endpoint
 enableEndpoint();
@@ -37,9 +38,13 @@ export const refresh = (
     const keyItem = KeyGeneration.generateKeyItem(id);
     Logger.info(`Key generated with id ${id}`, logContext, keyItem);
 
+    // Get claim for receipt
+    const claim: string = new OhttpPublicKey(keyItem, logContext).get();
+    Logger.info(`Claim generated for receipt: `, logContext, claim);
+
     // Store HPKE key pair using kid
     keyItem.kid = `${keyItem.kid!}`;
-    hpkeKeyMap.storeItem(id, keyItem, keyItem.x + keyItem.y);
+    hpkeKeyMap.storeItem(id, keyItem, claim);
     Logger.info(`Key item with id ${id} and kid ${keyItem.kid} stored`, logContext);
 
     delete keyItem.d;

--- a/test/inference-system-test/test_receipts.py
+++ b/test/inference-system-test/test_receipts.py
@@ -29,7 +29,7 @@ def test_validate_receipt(setup_kms):
     # In order to calculate the leaf value we need to hash all leaf_components
     write_set_digest = bytes.fromhex(receipt["leaf_components"]["write_set_digest"])
     claims_digest = bytes.fromhex(receipt["leaf_components"]["claims_digest"])
-    assert len(receipt['signature']) >= 138
+    assert len(receipt['signature']) >= 100
 
     commit_evidence_digest = sha256(
         receipt["leaf_components"]["commit_evidence"].encode()

--- a/test/inference-system-test/test_receipts.py
+++ b/test/inference-system-test/test_receipts.py
@@ -1,0 +1,61 @@
+import pytest
+import json
+import ccf.receipt
+from hashlib import sha256
+from cryptography.x509 import load_pem_x509_certificate
+from cryptography.hazmat.backends import default_backend
+from endpoints import listpubkeys, refresh
+
+def test_validate_receipt(setup_kms):
+    refresh()
+    
+    while True:
+        status_code, pubkeys = listpubkeys()
+        if status_code != 202:
+            break
+
+    assert status_code == 200
+
+    publicKey = pubkeys[0]['publicKey']
+    receipt = json.loads(pubkeys[0]['receipt'])
+
+    print("public key to validate: ", publicKey)
+    print("receipt to validate: ", json.dumps(receipt, indent=4))
+
+    # validate receipt
+    assert len(receipt['signature']) > 0
+    assert "leaf_components" in receipt
+
+    # In order to calculate the leaf value we need to hash all leaf_components
+    write_set_digest = bytes.fromhex(receipt["leaf_components"]["write_set_digest"])
+    claims_digest = bytes.fromhex(receipt["leaf_components"]["claims_digest"])
+    assert len(receipt['signature']) >= 138
+
+    commit_evidence_digest = sha256(
+        receipt["leaf_components"]["commit_evidence"].encode()
+    ).digest()
+    leaf = (
+        sha256(write_set_digest + commit_evidence_digest + claims_digest)
+            .digest()
+            .hex()
+        )
+    
+    # Get the root of the merkle tree
+    root = ccf.receipt.root(leaf, receipt["proof"])
+
+    # Get the certificate from the payload. Needs to be endorsed
+    node_cert = load_pem_x509_certificate(receipt["cert"].encode(), default_backend())
+
+    # Verify the merkle tree signature
+    ccf.receipt.verify(root, receipt["signature"], node_cert)
+
+    # get claims digest
+    claims = publicKey.encode()
+    claims_digest = sha256(claims).digest().hex()
+    
+    # validate claims digest
+    assert claims_digest == receipt["leaf_components"]["claims_digest"]
+    
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-s"])


### PR DESCRIPTION
To ease receipt validation in clients we want the receipt claim to be based on the OHHTP public key.
Small tweak in README